### PR TITLE
Delete exess elements in ngx_stream_limit_ups_module_ctx

### DIFF
--- a/ngx_stream_limit_upstream_module.c
+++ b/ngx_stream_limit_upstream_module.c
@@ -176,9 +176,6 @@ static ngx_stream_module_t ngx_stream_limit_ups_module_ctx = {
 
     ngx_stream_limit_ups_create_srv_conf,
     ngx_stream_limit_ups_merge_srv_conf,
-
-    NULL,
-    NULL
 };
 
 


### PR DESCRIPTION
```
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g -g -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffile-prefix-map=/src/nginx=. -flto=auto -ffat-lto-objects -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fdebug-prefix-map=/src/nginx=/usr/src/nginx-1.28.0+mod.4-1hn1ubuntu24.04 -fPIC -Wno-missing-field-initializers -Wno-implicit-fallthrough -I/usr/include/luajit-2.1 -DNDK_SET_VAR -DNDK_SET_VAR -DNDK_UPSTREAM_LIST -DLIBINJECTION_VERSION=0 -I./naxsi/naxsi_src/libinjection_ngxbuild/ -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I src/http/modules/perl -I ./ngx_devel_kit/objs -I objs/addon/ndk -I ./lua-nginx-module/src/api -I ./nginx-rtmp-module -I ./njs/nginx/../src -I ./njs/nginx/../build -I ./njs/nginx/../src -I ./njs/nginx/../build -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I src/http/modules/perl -I ./ngx_devel_kit/objs -I objs/addon/ndk -I ./lua-nginx-module/src/api -I ./nginx-rtmp-module -I ./njs/nginx/../src -I ./njs/nginx/../build -I ./njs/nginx/../src -I ./njs/nginx/../build -I -pipe -I -O -I -W -I -Wall -I -Wpointer-arith -I -Wno-unused-parameter -I -Werror -I -g -I -g -I -O2 -I -fno-omit-frame-pointer -I -mno-omit-leaf-frame-pointer -I -ffile-prefix-map=/src/nginx=. -I -flto=auto -I -ffat-lto-objects -I -specs=/usr/share/dpkg/no-pie-compile.specs -I -fstack-protector-strong -I -fstack-clash-protection -I -Wformat -I -Werror=format-security -I -fcf-protection -I -fdebug-prefix-map=/src/nginx=/usr/src/nginx-1.28.0+mod.4-1hn1ubuntu24.04 -I -fPIC -I -Wno-missing-field-initializers -I -Wno-implicit-fallthrough -I -I/usr/include/luajit-2.1 -I -DNDK_SET_VAR -I -DNDK_SET_VAR -I -DNDK_UPSTREAM_LIST -I ./ngx_mruby/mruby/src -I ./ngx_mruby/mruby/include -I ./naxsi/naxsi_src/ -I src/stream -I /usr/include/libxml2 -I objs -I src/http -I src/http/modules -I src/http/v2 -I src/http/v3 -I ./ngx_devel_kit/src -I ./ngx_devel_kit/src -I ./ngx_devel_kit/objs -I objs/addon/ndk -I src/mail -I src/stream \
      -o objs/addon/nginx-limit-upstream/ngx_stream_limit_upstream_module.o \
      ./nginx-limit-upstream/ngx_stream_limit_upstream_module.c

./nginx-limit-upstream/ngx_stream_limit_upstream_module.c:180:5: error: excess elements in struct initializer [-Werror]
  180 |     NULL,
      |     ^~~~
./nginx-limit-upstream/ngx_stream_limit_upstream_module.c:180:5: note: (near initialization for 'ngx_stream_limit_ups_module_ctx')
./nginx-limit-upstream/ngx_stream_limit_upstream_module.c:181:5: error: excess elements in struct initializer [-Werror]
  181 |     NULL
      |     ^~~~
./nginx-limit-upstream/ngx_stream_limit_upstream_module.c:181:5: note: (near initialization for 'ngx_stream_limit_ups_module_ctx')
```