### PR TITLE
Return 504 instead of 408 when connection to upstream is timed out

### DIFF
--- a/ngx_http_limit_upstream_module.c
+++ b/ngx_http_limit_upstream_module.c
@@ -228,7 +228,7 @@ ngx_http_limit_upstream_timeout(ngx_http_request_t *r)
     l = ctx->lnode;
     l->qlen--;
 
-    ngx_http_finalize_request(r, NGX_HTTP_REQUEST_TIME_OUT);
+    ngx_http_finalize_request(r, NGX_HTTP_GATEWAY_TIME_OUT);
 }
 
 


### PR DESCRIPTION
I suppose 408 Request Timeout is used for the case when a client is too slow to send a request.
https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout